### PR TITLE
Adding initial notebooks

### DIFF
--- a/MeltRate.ipynb
+++ b/MeltRate.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ecc44fa4-6561-49ee-83c2-738b02743ca9",
+   "metadata": {},
+   "source": [
+    "# Generating Melt Rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "434e5230-3b0f-48aa-9a3b-752f2328e980",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "CSDMS",
+   "language": "python",
+   "name": "csdms-2023"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/OverlandFlow.ipynb
+++ b/OverlandFlow.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ecc44fa4-6561-49ee-83c2-738b02743ca9",
+   "metadata": {},
+   "source": [
+    "# OverlandFlow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "434e5230-3b0f-48aa-9a3b-752f2328e980",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "CSDMS",
+   "language": "python",
+   "name": "csdms-2023"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adding two notebooks: one for generating melt and the other for computing overland flow. By keeping them in different notebooks, we'll reduce merge conflicts.